### PR TITLE
Fix cpu snoop

### DIFF
--- a/snoop/cpu_snoop.py
+++ b/snoop/cpu_snoop.py
@@ -268,10 +268,12 @@ class CPUSnoop:
         for k, v in sorted(self.bpf['cpu_time'].items_lookup_and_delete_batch(), key=lambda kv: (kv[1].oncpu_time), reverse=True):
             comm = pid_to_comm(k).strip('\n')
             oncpu_time_ms = v.oncpu_time / 1e6
-            offcpu_time_ms = v.offcpu_time / 1e6
-            total_time_ms = oncpu_time_ms + offcpu_time_ms
+            # offcpu_time_ms = v.offcpu_time / 1e6
+            offcpu_time_ms = period - oncpu_time_ms
+            # total_time_ms = oncpu_time_ms + offcpu_time_ms
+            total_time_ms = period
             # utilization = oncpu_time_ms / total_time_ms if total_time_ms > 0 else 0
-            utilization = oncpu_time_ms / total_time_ms if not total_time_ms == 0 else 0
+            utilization = oncpu_time_ms / total_time_ms if total_time_ms > 0.1 else 0
             # self.output_file.write("%-12.2f %-12d %-20s %-20.2f %-20.2f %-20.2f\n" % (
             #                         time_stamp,
             #                         k, 
@@ -280,7 +282,7 @@ class CPUSnoop:
             #                         offcpu_time_ms,
             #                         utilization * 100,
             #                         ))
-            self.output_file.write("%.2f,%12d,%20s,%2f,%.2f,%.2f\n" % (
+            self.output_file.write("%.2f,%12d,%20s,%.2f,%.2f,%.2f\n" % (
                                     time_stamp,
                                     k, 
                                     comm,
@@ -292,7 +294,7 @@ class CPUSnoop:
             self.output_file.flush()
 
     def main_loop(self, interval, process_cpu_time):
-        prev_time = time.time()
+        prev_time = self.start_time
         while True:
             try:
                 sleep(interval)
@@ -310,6 +312,7 @@ class CPUSnoop:
     def run(self, interval, output_filename, snoop_pid):
         self.generate_program(snoop_pid=snoop_pid)
         self.attatch_probe()
+        self.start_time = time.time()
         self.cpu_time = self.bpf['cpu_time']
         process_cpu_time = {}
 
@@ -323,6 +326,7 @@ class CPUSnoop:
 
 if __name__=="__main__":
     snoop = CPUSnoop()
-    pid = run_command_get_pid("/home/li/repository/bcc_detector/OSdetector/test_examples/mem")
-    snoop.run(interval=1, output_filename="tmp.csv", snoop_pid=pid)
+    pid = run_command_get_pid("../test_examples/cpu")
+    print(pid)
+    snoop.run(interval=20, output_filename="tmp.csv", snoop_pid=pid)
 

--- a/snoop/top_snoop.py
+++ b/snoop/top_snoop.py
@@ -34,7 +34,7 @@ class TOPSnoop():
             help="id of the process to trace (optional)")
         parser.add_argument("-c", "--command",
             help="execute and trace the specified command (optional)")
-        parser.add_argument("-i", "--interval", type=int, default=1,
+        parser.add_argument("-i", "--interval", type=int, default=15,
             help="The interval of snoop (unit:s)")
         args = parser.parse_args()
         if args.command is not None:
@@ -42,9 +42,14 @@ class TOPSnoop():
             popen = run_command(args.command)
             self.popens.append(popen)
             self.snoop_pid = popen.pid
-        else:
+        elif args.pid is not None:
             self.snoop_pid = args.pid
+        else:
+            print("Please specify the pid or command!")
+            exit()
         self.interval = args.interval
+        if self.interval < 20:
+            print("Set interval smaller than 20 second may cause inaccuracy in CPU utilization")
     
     def run(self):
         cpu_snoop_process = mp.Process(target=self.cpu_snoop.run, args=(self.interval, "cpu.csv", self.snoop_pid))


### PR DESCRIPTION
改进进程CPU占用率监控模块。
- 原来计算OFF-CPU时间方式存在漏洞，现修改为用输出周期减去ON-CPU时间。
- 通过延长输出周期缓解不稳定现象。
- 在top_snoop模块修改默认输出周期，增加输出周期设定过小可能导致CPU占用率计算不准确的警告。